### PR TITLE
Allow publishing from new tags with the same Webots version

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Determine Version
       run: |
         # Strip git ref prefix from version
-        IMAGE_TAG=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+        IMAGE_TAG=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,') | sed -e 's,\_.*,,'
         # Use Docker `latest` tag convention
         [ "$IMAGE_TAG" == "master" ] && IMAGE_TAG=latest
         # Webots version
@@ -61,7 +61,7 @@ jobs:
           # Change all uppercase to lowercase
           IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
           # Strip git ref prefix from version
-          IMAGE_TAG=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          IMAGE_TAG=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,') | sed -e 's,\_.*,,'
           # Use Docker `latest` tag convention
           [ "$IMAGE_TAG" == "master" ] && IMAGE_TAG=latest
           # Webots version


### PR DESCRIPTION
Here we have a list of Webots Docker images:
https://hub.docker.com/r/cyberbotics/webots/tags

Notice that `latest` is published 6/10/2020, while the other tags (like `R2020b-rev1-ubuntu20.04` or `R2020b-rev1-ubuntu18.04`) are published 14/9/2020. `latest` is published from the master branch while the others are published from Git tags. The `latest` tag contains fix e8a1fb0 which we currently cannot include in the Docker images with specific tags  (like `R2020b-rev1-ubuntu20.04` or `R2020b-rev1-ubuntu18.04`) because we cannot have multiple tags with the same name.

This PR will allow us to create multiple tags for a single Webots version. For example, we will be able have Git tag `R2020b-rev1-ubuntu20.04_v1`, `R2020b-rev1-ubuntu20.04_v2`, `R2020b-rev1-ubuntu20.04_v3` and so on.