### PR TITLE
Fix NVIDIA CUDA Linux Repository Key Rotation

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        BASE_IMAGE: ["nvidia/cudagl:10.0-devel-ubuntu18.04", "nvidia/cudagl:11.0-devel-ubuntu20.04"]
+        BASE_IMAGE: ["nvidia/cudagl:11.4.2-devel-ubuntu18.04", "nvidia/cudagl:11.4.2-devel-ubuntu20.04"]
         include:
-          - BASE_IMAGE: "nvidia/cudagl:10.0-devel-ubuntu18.04"
+          - BASE_IMAGE: "nvidia/cudagl:11.4.2-devel-ubuntu18.04"
             WEBOTS_PACKAGE_PREFIX: "_ubuntu-18.04"
     steps:
     - uses: actions/checkout@v2
@@ -48,9 +48,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        BASE_IMAGE: ["nvidia/cudagl:10.0-devel-ubuntu18.04", "nvidia/cudagl:11.0-devel-ubuntu20.04"]
+        BASE_IMAGE: ["nvidia/cudagl:11.4.2-devel-ubuntu18.04", "nvidia/cudagl:11.4.2-devel-ubuntu20.04"]
         include:
-          - BASE_IMAGE: "nvidia/cudagl:10.0-devel-ubuntu18.04"
+          - BASE_IMAGE: "nvidia/cudagl:11.4.2-devel-ubuntu18.04"
             WEBOTS_PACKAGE_PREFIX: "_ubuntu-18.04"
     if: github.event_name == 'push'
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        BASE_IMAGE: ["nvidia/cudagl:10.0-devel-ubuntu18.04", "nvidia/cudagl:11.0-devel-ubuntu20.04"]
+        BASE_IMAGE: ["nvidia/cudagl:11.4.2-devel-ubuntu18.04", "nvidia/cudagl:11.4.2-devel-ubuntu20.04"]
         include:
-          - BASE_IMAGE: "nvidia/cudagl:10.0-devel-ubuntu18.04"
+          - BASE_IMAGE: "nvidia/cudagl:11.4.2-devel-ubuntu18.04"
             WEBOTS_PACKAGE_PREFIX: "_ubuntu-18.04"
     steps:
       - uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,9 @@ ARG WEBOTS_PACKAGE_PREFIX=
 
 # Install Webots runtime dependencies
 RUN apt-key del 7fa2af80
-RUN curl -O https://developer.download.nvidia.com/compute/cuda/repos/ubuntu$(cat /etc/os-release | grep VERSION_ID | awk '{print substr($0,13,5)}' | awk -F'.' '{print $1$2}')/x86_64/cuda-keyring_1.0-1_all.deb
-RUN dpkg -i cuda-keyring_1.0-1_all.deb
 RUN apt update && apt install --yes wget && rm -rf /var/lib/apt/lists/
+RUN wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu$(cat /etc/os-release | grep VERSION_ID | awk '{print substr($0,13,5)}' | awk -F'.' '{print $1$2}')/x86_64/cuda-keyring_1.0-1_all.deb
+RUN dpkg -i cuda-keyring_1.0-1_all.deb
 RUN wget https://raw.githubusercontent.com/cyberbotics/webots/master/scripts/install/linux_runtime_dependencies.sh
 RUN chmod +x linux_runtime_dependencies.sh && ./linux_runtime_dependencies.sh && rm ./linux_runtime_dependencies.sh && rm -rf /var/lib/apt/lists/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,9 @@ ARG WEBOTS_PACKAGE_PREFIX=
 
 # Install Webots runtime dependencies
 RUN apt-key del 7fa2af80
-RUN apt install --yes wget
-RUN wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu$(cat /etc/os-release | grep VERSION_ID | awk '{print substr($0,13,5)}' | awk -F'.' '{print $1$2}')/x86_64/cuda-keyring_1.0-1_all.deb
-RUN dpkg -i cuda-keyring_1.0-1_all.deb
+RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu$(cat /etc/os-release | grep VERSION_ID | awk '{print substr($0,13,5)}' | awk -F'.' '{print $1$2}')/3bf863cc.pub
+# RUN wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu$(cat /etc/os-release | grep VERSION_ID | awk '{print substr($0,13,5)}' | awk -F'.' '{print $1$2}')/x86_64/cuda-keyring_1.0-1_all.deb
+# RUN dpkg -i cuda-keyring_1.0-1_all.deb
 RUN apt update && apt install --yes wget && rm -rf /var/lib/apt/lists/
 RUN wget https://raw.githubusercontent.com/cyberbotics/webots/master/scripts/install/linux_runtime_dependencies.sh
 RUN chmod +x linux_runtime_dependencies.sh && ./linux_runtime_dependencies.sh && rm ./linux_runtime_dependencies.sh && rm -rf /var/lib/apt/lists/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=nvidia/cudagl:11.0-devel-ubuntu20.04
+ARG BASE_IMAGE=nvidia/cudagl:11.4.2-devel-ubuntu20.04
 FROM ${BASE_IMAGE}
 
 # Disable dpkg/gdebi interactive dialogs

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,9 @@ ARG WEBOTS_VERSION=R2022a
 ARG WEBOTS_PACKAGE_PREFIX=
 
 # Install Webots runtime dependencies
-RUN echo {BASE_IMAGE}
+RUN echo $BASE_IMAGE
 RUN apt-key del 7fa2af80
-RUN https://developer.download.nvidia.com/compute/cuda/repos/ubuntu$(printenv BASE_IMAGE | awk '{print substr($0,length($0)-4,5)}' | awk -F'.' '{print $1$2}')/x86_64/cuda-keyring_1.0-1_all.deb
+RUN https://developer.download.nvidia.com/compute/cuda/repos/ubuntu$(echo $BASE_IMAGE | awk '{print substr($0,length($0)-4,5)}' | awk -F'.' '{print $1$2}')/x86_64/cuda-keyring_1.0-1_all.deb
 RUN dpkg -i cuda-keyring_1.0-1_all.deb
 RUN apt update && apt install --yes wget && rm -rf /var/lib/apt/lists/
 RUN wget https://raw.githubusercontent.com/cyberbotics/webots/master/scripts/install/linux_runtime_dependencies.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ARG WEBOTS_PACKAGE_PREFIX=
 
 # Install Webots runtime dependencies
 RUN apt-key del 7fa2af80
-RUN https://developer.download.nvidia.com/compute/cuda/repos/ubuntu$(echo $BASE_IMAGE | awk '{print substr($0,length($0)-4,5)}' | awk -F'.' '{print $1$2}')/x86_64/cuda-keyring_1.0-1_all.deb
+RUN https://developer.download.nvidia.com/compute/cuda/repos/ubuntu$(echo nvidia/cudagl:11.4.2-devel-ubuntu20.04 | awk '{print substr($0,length($0)-4,5)}' | awk -F'.' '{print $1$2}')/x86_64/cuda-keyring_1.0-1_all.deb
 RUN dpkg -i cuda-keyring_1.0-1_all.deb
 RUN apt update && apt install --yes wget && rm -rf /var/lib/apt/lists/
 RUN wget https://raw.githubusercontent.com/cyberbotics/webots/master/scripts/install/linux_runtime_dependencies.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ ARG WEBOTS_PACKAGE_PREFIX=
 
 # Install Webots runtime dependencies
 RUN apt-key del 7fa2af80
+RUN apt-get install --yes lsb-release
 RUN https://developer.download.nvidia.com/compute/cuda/repos/ubuntu$(lsb_release -r | awk '{print $2}' | awk -F'.' '{print $1$2}')/x86_64/cuda-keyring_1.0-1_all.deb
 RUN dpkg -i cuda-keyring_1.0-1_all.deb
 RUN apt update && apt install --yes wget && rm -rf /var/lib/apt/lists/

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ARG WEBOTS_VERSION=R2022a
 ARG WEBOTS_PACKAGE_PREFIX=
 
 # Install Webots runtime dependencies
-RUN printenv BASE_IMAGE
+RUN echo {BASE_IMAGE}
 RUN apt-key del 7fa2af80
 RUN https://developer.download.nvidia.com/compute/cuda/repos/ubuntu$(printenv BASE_IMAGE | awk '{print substr($0,length($0)-4,5)}' | awk -F'.' '{print $1$2}')/x86_64/cuda-keyring_1.0-1_all.deb
 RUN dpkg -i cuda-keyring_1.0-1_all.deb

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ ARG WEBOTS_VERSION=R2022a
 ARG WEBOTS_PACKAGE_PREFIX=
 
 # Install Webots runtime dependencies
+RUN apt-key del 7fa2af80
+RUN https://developer.download.nvidia.com/compute/cuda/repos/ubuntu$(lsb_release -r | awk '{print $2}' | awk -F'.' '{print $1$2}')/x86_64/cuda-keyring_1.0-1_all.deb
+RUN dpkg -i cuda-keyring_1.0-1_all.deb
 RUN apt update && apt install --yes wget && rm -rf /var/lib/apt/lists/
 RUN wget https://raw.githubusercontent.com/cyberbotics/webots/master/scripts/install/linux_runtime_dependencies.sh
 RUN chmod +x linux_runtime_dependencies.sh && ./linux_runtime_dependencies.sh && rm ./linux_runtime_dependencies.sh && rm -rf /var/lib/apt/lists/

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,11 @@ ENV DEBIAN_FRONTEND=noninteractive
 ARG WEBOTS_VERSION=R2022a
 ARG WEBOTS_PACKAGE_PREFIX=
 
-# Install Webots runtime dependencies
+# Fix NVIDIA CUDA Linux repository key rotation
 RUN apt-key del 7fa2af80
 RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu$(cat /etc/os-release | grep VERSION_ID | awk '{print substr($0,13,5)}' | awk -F'.' '{print $1$2}')/x86_64/3bf863cc.pub
+
+# Install Webots runtime dependencies
 RUN apt update && apt install --yes wget && rm -rf /var/lib/apt/lists/
 RUN wget https://raw.githubusercontent.com/cyberbotics/webots/master/scripts/install/linux_runtime_dependencies.sh
 RUN chmod +x linux_runtime_dependencies.sh && ./linux_runtime_dependencies.sh && rm ./linux_runtime_dependencies.sh && rm -rf /var/lib/apt/lists/

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ ARG WEBOTS_PACKAGE_PREFIX=
 
 # Fix NVIDIA CUDA Linux repository key rotation
 RUN apt-key del 7fa2af80
+ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1
 RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu$(cat /etc/os-release | grep VERSION_ID | awk '{print substr($0,13,5)}' | awk -F'.' '{print $1$2}')/x86_64/3bf863cc.pub
 
 # Install Webots runtime dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,6 @@ ARG WEBOTS_PACKAGE_PREFIX=
 # Install Webots runtime dependencies
 RUN apt-key del 7fa2af80
 RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu$(cat /etc/os-release | grep VERSION_ID | awk '{print substr($0,13,5)}' | awk -F'.' '{print $1$2}')/x86_64/3bf863cc.pub
-# RUN wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu$(cat /etc/os-release | grep VERSION_ID | awk '{print substr($0,13,5)}' | awk -F'.' '{print $1$2}')/x86_64/cuda-keyring_1.0-1_all.deb
-# RUN dpkg -i cuda-keyring_1.0-1_all.deb
 RUN apt update && apt install --yes wget && rm -rf /var/lib/apt/lists/
 RUN wget https://raw.githubusercontent.com/cyberbotics/webots/master/scripts/install/linux_runtime_dependencies.sh
 RUN chmod +x linux_runtime_dependencies.sh && ./linux_runtime_dependencies.sh && rm ./linux_runtime_dependencies.sh && rm -rf /var/lib/apt/lists/

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ARG WEBOTS_PACKAGE_PREFIX=
 
 # Install Webots runtime dependencies
 RUN apt-key del 7fa2af80
-RUN https://developer.download.nvidia.com/compute/cuda/repos/ubuntu$(cat /etc/os-release | grep VERSION_ID | awk '{print substr($0,13,5)}' | awk -F'.' '{print $1$2}')/x86_64/cuda-keyring_1.0-1_all.deb
+RUN wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu$(cat /etc/os-release | grep VERSION_ID | awk '{print substr($0,13,5)}' | awk -F'.' '{print $1$2}')/x86_64/cuda-keyring_1.0-1_all.deb
 RUN dpkg -i cuda-keyring_1.0-1_all.deb
 RUN apt update && apt install --yes wget && rm -rf /var/lib/apt/lists/
 RUN wget https://raw.githubusercontent.com/cyberbotics/webots/master/scripts/install/linux_runtime_dependencies.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,10 @@ ARG WEBOTS_PACKAGE_PREFIX=
 
 # Install Webots runtime dependencies
 RUN apt-key del 7fa2af80
-RUN apt update && apt install --yes wget && rm -rf /var/lib/apt/lists/
+RUN apt install --yes wget
 RUN wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu$(cat /etc/os-release | grep VERSION_ID | awk '{print substr($0,13,5)}' | awk -F'.' '{print $1$2}')/x86_64/cuda-keyring_1.0-1_all.deb
 RUN dpkg -i cuda-keyring_1.0-1_all.deb
+RUN apt update && apt install --yes wget && rm -rf /var/lib/apt/lists/
 RUN wget https://raw.githubusercontent.com/cyberbotics/webots/master/scripts/install/linux_runtime_dependencies.sh
 RUN chmod +x linux_runtime_dependencies.sh && ./linux_runtime_dependencies.sh && rm ./linux_runtime_dependencies.sh && rm -rf /var/lib/apt/lists/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ARG WEBOTS_PACKAGE_PREFIX=
 
 # Install Webots runtime dependencies
 RUN apt-key del 7fa2af80
-RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu$(cat /etc/os-release | grep VERSION_ID | awk '{print substr($0,13,5)}' | awk -F'.' '{print $1$2}')/3bf863cc.pub
+RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu$(cat /etc/os-release | grep VERSION_ID | awk '{print substr($0,13,5)}' | awk -F'.' '{print $1$2}')/x86_64/3bf863cc.pub
 # RUN wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu$(cat /etc/os-release | grep VERSION_ID | awk '{print substr($0,13,5)}' | awk -F'.' '{print $1$2}')/x86_64/cuda-keyring_1.0-1_all.deb
 # RUN dpkg -i cuda-keyring_1.0-1_all.deb
 RUN apt update && apt install --yes wget && rm -rf /var/lib/apt/lists/

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,9 @@ ARG WEBOTS_VERSION=R2022a
 ARG WEBOTS_PACKAGE_PREFIX=
 
 # Install Webots runtime dependencies
-RUN echo $BASE_IMAGE
+RUN echo ${BASE_IMAGE}
 RUN apt-key del 7fa2af80
-RUN https://developer.download.nvidia.com/compute/cuda/repos/ubuntu$(echo $BASE_IMAGE | awk '{print substr($0,length($0)-4,5)}' | awk -F'.' '{print $1$2}')/x86_64/cuda-keyring_1.0-1_all.deb
+RUN https://developer.download.nvidia.com/compute/cuda/repos/ubuntu$(echo ${BASE_IMAGE} | awk '{print substr($0,length($0)-4,5)}' | awk -F'.' '{print $1$2}')/x86_64/cuda-keyring_1.0-1_all.deb
 RUN dpkg -i cuda-keyring_1.0-1_all.deb
 RUN apt update && apt install --yes wget && rm -rf /var/lib/apt/lists/
 RUN wget https://raw.githubusercontent.com/cyberbotics/webots/master/scripts/install/linux_runtime_dependencies.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,15 @@ FROM ${BASE_IMAGE}
 # Disable dpkg/gdebi interactive dialogs
 ENV DEBIAN_FRONTEND=noninteractive
 
+ENV BASE_IMAGE ${BASE_IMAGE}
+
 # Determine Webots version to be used and set default argument
 ARG WEBOTS_VERSION=R2022a
 ARG WEBOTS_PACKAGE_PREFIX=
 
 # Install Webots runtime dependencies
 RUN apt-key del 7fa2af80
-RUN apt-get install --yes lsb-release
-RUN https://developer.download.nvidia.com/compute/cuda/repos/ubuntu$(lsb_release -r | awk '{print $2}' | awk -F'.' '{print $1$2}')/x86_64/cuda-keyring_1.0-1_all.deb
+RUN https://developer.download.nvidia.com/compute/cuda/repos/ubuntu$(echo $BASE_IMAGE | awk '{print substr($0,length($0)-4,5)}' | awk -F'.' '{print $1$2}')/x86_64/cuda-keyring_1.0-1_all.deb
 RUN dpkg -i cuda-keyring_1.0-1_all.deb
 RUN apt update && apt install --yes wget && rm -rf /var/lib/apt/lists/
 RUN wget https://raw.githubusercontent.com/cyberbotics/webots/master/scripts/install/linux_runtime_dependencies.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,15 +4,16 @@ FROM ${BASE_IMAGE}
 # Disable dpkg/gdebi interactive dialogs
 ENV DEBIAN_FRONTEND=noninteractive
 
-ENV BASE_IMAGE ${BASE_IMAGE}
+ENV BASE_IMAGE $BASE_IMAGE
 
 # Determine Webots version to be used and set default argument
 ARG WEBOTS_VERSION=R2022a
 ARG WEBOTS_PACKAGE_PREFIX=
 
 # Install Webots runtime dependencies
+RUN printenv BASE_IMAGE
 RUN apt-key del 7fa2af80
-RUN https://developer.download.nvidia.com/compute/cuda/repos/ubuntu$(echo nvidia/cudagl:11.4.2-devel-ubuntu20.04 | awk '{print substr($0,length($0)-4,5)}' | awk -F'.' '{print $1$2}')/x86_64/cuda-keyring_1.0-1_all.deb
+RUN https://developer.download.nvidia.com/compute/cuda/repos/ubuntu$(printenv BASE_IMAGE | awk '{print substr($0,length($0)-4,5)}' | awk -F'.' '{print $1$2}')/x86_64/cuda-keyring_1.0-1_all.deb
 RUN dpkg -i cuda-keyring_1.0-1_all.deb
 RUN apt update && apt install --yes wget && rm -rf /var/lib/apt/lists/
 RUN wget https://raw.githubusercontent.com/cyberbotics/webots/master/scripts/install/linux_runtime_dependencies.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ARG WEBOTS_PACKAGE_PREFIX=
 
 # Install Webots runtime dependencies
 RUN apt-key del 7fa2af80
-RUN wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu$(cat /etc/os-release | grep VERSION_ID | awk '{print substr($0,13,5)}' | awk -F'.' '{print $1$2}')/x86_64/cuda-keyring_1.0-1_all.deb
+RUN curl -O https://developer.download.nvidia.com/compute/cuda/repos/ubuntu$(cat /etc/os-release | grep VERSION_ID | awk '{print substr($0,13,5)}' | awk -F'.' '{print $1$2}')/x86_64/cuda-keyring_1.0-1_all.deb
 RUN dpkg -i cuda-keyring_1.0-1_all.deb
 RUN apt update && apt install --yes wget && rm -rf /var/lib/apt/lists/
 RUN wget https://raw.githubusercontent.com/cyberbotics/webots/master/scripts/install/linux_runtime_dependencies.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,16 +4,13 @@ FROM ${BASE_IMAGE}
 # Disable dpkg/gdebi interactive dialogs
 ENV DEBIAN_FRONTEND=noninteractive
 
-ENV BASE_IMAGE $BASE_IMAGE
-
 # Determine Webots version to be used and set default argument
 ARG WEBOTS_VERSION=R2022a
 ARG WEBOTS_PACKAGE_PREFIX=
 
 # Install Webots runtime dependencies
-RUN echo ${BASE_IMAGE}
 RUN apt-key del 7fa2af80
-RUN https://developer.download.nvidia.com/compute/cuda/repos/ubuntu$(echo ${BASE_IMAGE} | awk '{print substr($0,length($0)-4,5)}' | awk -F'.' '{print $1$2}')/x86_64/cuda-keyring_1.0-1_all.deb
+RUN https://developer.download.nvidia.com/compute/cuda/repos/ubuntu$(cat /etc/os-release | grep VERSION_ID | awk '{print substr($0,13,5)}' | awk -F'.' '{print $1$2}')/x86_64/cuda-keyring_1.0-1_all.deb
 RUN dpkg -i cuda-keyring_1.0-1_all.deb
 RUN apt update && apt install --yes wget && rm -rf /var/lib/apt/lists/
 RUN wget https://raw.githubusercontent.com/cyberbotics/webots/master/scripts/install/linux_runtime_dependencies.sh


### PR DESCRIPTION
A user reported problem with the docker image:
```
GPG error: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64  InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY A4B469963BF863CC
#11 30.69 E: The repository 'https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64  InRelease' is not signed.
```
And pointed out this [post](https://forums.developer.nvidia.com/t/notice-cuda-linux-repository-key-rotation/212772).

This PR attempts to fix the problem by updating the NVIDIA base images.