### PR TITLE
Dockerfile webots cloud

### DIFF
--- a/Dockerfile_webots_cloud
+++ b/Dockerfile_webots_cloud
@@ -10,6 +10,7 @@ RUN apt update && apt install --yes unzip && \
   cd assets && unzip assets-$WEBOTS_VERSION.zip && rm assets-$WEBOTS_VERSION.zip
 
 FROM $BASE_IMAGE
+ARG WEBOTS_VERSION=R2022b
 
 COPY Webots-R2022b.conf /root/.config/Cyberbotics/Webots-$WEBOTS_VERSION.conf
 COPY --from=downloader /usr/local/assets /root/.cache/Cyberbotics/Webots/assets/


### PR DESCRIPTION
We are building two images for the cloud-optimized docker.
- An intermediary one to download and get the assets.
- The final one.

The declaration of the `WEBOTS_VERSION` global variable was missing in the second image.

The new Docker are already push on hub.docker.com and deployed on the servers