### PR TITLE
Enable GPU compute for controllers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,8 @@ ENV WEBOTS_HOME /usr/local/webots
 ENV PATH /usr/local/webots:${PATH}
 
 # Enable OpenGL capabilities
-ENV NVIDIA_DRIVER_CAPABILITIES=graphics
+ENV NVIDIA_DRIVER_CAPABILITIES graphics,compute,utility
+ENV NVIDIA_VISIBLE_DEVICES all
 
 # Finally open a bash command to let the user interact
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,6 @@ ENV PATH /usr/local/webots:${PATH}
 
 # Enable OpenGL capabilities
 ENV NVIDIA_DRIVER_CAPABILITIES graphics,compute,utility
-ENV NVIDIA_VISIBLE_DEVICES all
 
 # Finally open a bash command to let the user interact
 CMD ["/bin/bash"]


### PR DESCRIPTION
This PR enables the GPU compute inside the docker, so that controllers using GPU (Pytorch, TensorFlow, etc.) can get hardware acceleration as well.